### PR TITLE
feat(Delete office) A user can delete an existing office

### DIFF
--- a/app/api/v2/models/offices_model.py
+++ b/app/api/v2/models/offices_model.py
@@ -52,3 +52,10 @@ class OfficesModel(Database):
 		self.conn.commit()
 		self.curr.close()
 		return user
+
+	def delete(self, office_id):
+		''' Delete order '''
+		
+		self.curr.execute(''' DELETE FROM offices WHERE office_id=%s''',(office_id, ))
+		self.conn.commit()
+		self.curr.close()

--- a/app/api/v2/views/office.py
+++ b/app/api/v2/views/office.py
@@ -60,3 +60,18 @@ class Office:
         return make_response(jsonify({
             "status": "not found"
             }), 404)
+
+    @office_v2.route('/offices/<int:office_id>/delete', methods=['DELETE'])
+    @jwt_required
+    def delete(office_id):
+        """Delete a specific office."""
+
+        office = OfficesModel().get_office_by_id(office_id)
+        if office:
+            OfficesModel().delete(office_id)
+            return make_response(jsonify({
+                "message": "office deleted"
+                }), 200)
+        return make_response(jsonify({
+            "status": "not found"
+            }), 404)

--- a/tests/v2/test_office.py
+++ b/tests/v2/test_office.py
@@ -71,6 +71,7 @@ class TestOffice(BaseTest):
 
 		response1 = self.client.post(
 			'/api/v2/auth/offices', data=json.dumps(create_office2), content_type='application/json', headers=self.get_token())
+		return response1
 		response = self.client.get(
 			'/api/v2/auth/offices/1', content_type='application/json', headers=self.get_token())
 		result = json.loads(response.data.decode())
@@ -95,5 +96,17 @@ class TestOffice(BaseTest):
 		result = json.loads(response.data.decode())
 		self.assertEqual(result['message'], 'The name of the office is in wrong format!')
 		assert response.status_code == 400
+
+	def test_delete_office(self):
+		"""Test deleting a specific office by id."""
+
+		response1 = self.client.post(
+			'/api/v2/auth/offices', data=json.dumps(create_office2), content_type='application/json', headers=self.get_token())
+		response = self.client.delete(
+			'/api/v2/auth/offices/1/delete', content_type='application/json', headers=self.get_token())
+		result = json.loads(response.data.decode())
+		self.assertEqual(result['message'],
+			'office deleted')
+		assert response.status_code == 200
 
 


### PR DESCRIPTION
**_What does this pr do?_**

Have a user able to delete an existing office

**_What are the tasks involved?_**

- create delete office endpoint
- write test to test the delete endpoint
- test the endpoint with postman

**_Any related pivotal stories?_**

[Finishes #164029743]

**_Screenshot?_**

 Delete an existing office

![officedeletedb](https://user-images.githubusercontent.com/42092300/52911561-6c3bd880-3273-11e9-92eb-e3885449de50.png)

