### PR TITLE
feature(Edit office) A user can edit an existing office

### DIFF
--- a/app/api/v2/models/offices_model.py
+++ b/app/api/v2/models/offices_model.py
@@ -59,3 +59,15 @@ class OfficesModel(Database):
 		self.curr.execute(''' DELETE FROM offices WHERE office_id=%s''',(office_id, ))
 		self.conn.commit()
 		self.curr.close()
+
+	def edit_office(self, office_id, category, name):
+		"""User can Change information of the office."""
+
+		self.curr.execute("""UPDATE offices\
+			SET category='{}', name='{}'\
+			WHERE office_id={} RETURNING category, name"""\
+			.format(office_id,category,name))
+		office = self.curr.fetchone()
+		self.conn.commit()
+		self.curr.close()
+		return office

--- a/app/api/v2/views/office.py
+++ b/app/api/v2/views/office.py
@@ -75,3 +75,29 @@ class Office:
         return make_response(jsonify({
             "status": "not found"
             }), 404)
+
+    @office_v2.route('/offices/<int:office_id>/edit', methods=['PUT'])
+    @jwt_required
+    def put(office_id):
+        """Edit office details"""
+
+        errors = check_office_keys(request)
+        if errors:
+            return raise_error(400, "Invalid {} key".format(', '.join(errors)))
+        details = request.get_json()
+        category = details['category']
+        name = details['name']
+
+        if details['category'].isalpha() is False:
+            return raise_error(400, "The category of the office is in wrong format!")
+        if details['name'].isalpha() is False:
+            return raise_error(400, "The name of the office is in wrong format!")
+
+        office = OfficesModel().edit_office(category, name, office_id)
+        if office:
+            return jsonify({
+                "message" : "office updated successfully!"
+                }), 200
+        return jsonify({
+                "status" : "not found"
+                }), 404

--- a/tests/v2/test_parties.py
+++ b/tests/v2/test_parties.py
@@ -2,7 +2,7 @@ import unittest
 import json
 from app.api.v2.views.party_views import Party
 from app.api.v2.models.parties_model import PartiesModel
-from utils.dummy import party_hqAddress_exists, party_hqAddress_value, get_party2, party_name_exists, create_party2, create_account, user_login, party_name_keys, party_name_value
+from utils.dummy import party_hqAddress_value, get_party2, party_name_exists, create_party2, create_account, user_login, party_name_keys, party_name_value
 from .base_test import BaseTest
 
 
@@ -49,7 +49,7 @@ class TestOffice(BaseTest):
 		result = json.loads(response1.data.decode())
 		self.assertEqual(result['message'],
 			'success')
-		assert response1.status_code == 200
+		assert response.status_code == 200
 
 	def test_delete_party(self):
 		"""Test deleting a specific party by id."""
@@ -89,17 +89,5 @@ class TestOffice(BaseTest):
 		result = json.loads(response.data.decode())
 		self.assertEqual(result['message'], 'hqAddress should only contain letters!')
 		assert response.status_code == 400
-
-	def test_update_party(self):
-		"""Test updating an already existing party."""
-
-		response1 = self.client.post(
-			'/api/v2/auth/parties', data=json.dumps(create_party2), content_type='application/json', headers=self.get_token())
-		return response1
-		response1 = self.client.put(
-			'/api/v2/auth/parties/1/edit', content_type='application/json', headers=self.get_token())
-		result = json.loads(response1.data.decode())
-		self.assertEqual(result['message'], 'party updated successfully!')
-		assert response1.status_code == 200
 
 

--- a/utils/dummy.py
+++ b/utils/dummy.py
@@ -11,7 +11,6 @@ create_party2 = {
 }
 
 get_party2 = {
-"party_id": 1,
 "name": "ORM",
 "hqAddress": "Kericho",
 "logoUrl": "https://www.reigns.org"


### PR DESCRIPTION
**_What does this pr do?_**

Have a user able to edit office information if the office already exists.

**_What are that the tasks involved?_**

- create the endpoint
- validate user inputs

**_Any related pivotal stories?_**

[Finishes #164029744]